### PR TITLE
chore(edit): change color to make comment readable (read desc)

### DIFF
--- a/theme-oceandeeper/themes/OceanDeeper-color-theme.json
+++ b/theme-oceandeeper/themes/OceanDeeper-color-theme.json
@@ -91,7 +91,7 @@
       "name": "Comment",
       "scope": "comment",
       "settings": {
-        "foreground": "#06151e",
+        "foreground": "#64788b",
         "fontStyle": "italic"
       }
     },


### PR DESCRIPTION
The color of the comments in the theme have been changed to '#64788b' from '#06151e' to make them more readable. The comments were previously almost invisible due to their color. On accepting this pull request and updating the theme, any coders using this theme will greatly appreciate you making the comments readable.